### PR TITLE
fix: 解析策略描述为空白的问题

### DIFF
--- a/web/backend/app.py
+++ b/web/backend/app.py
@@ -147,9 +147,17 @@ async def list_strategies():
             
             # 简单解析策略描述
             description = ""
+            ready_to_extract = False
             for line in content.split('\n'):
+                line = line.strip()
                 if '"""' in line or "'''" in line:
+                    if line in ['"""', "'''"]:
+                        ready_to_extract = True
+                        continue
                     description = line.strip(' "\'')
+                    break
+                elif ready_to_extract:
+                    description = line.strip()
                     break
             
             strategies.append({


### PR DESCRIPTION
Web 界面策略列表的描述字段由于 app.py 中解析策略注释的实现不准确，导致解析出来的描述是空白，这个补丁修复这个问题，兼容单行注释和多行注释（取第一行）的提取。